### PR TITLE
fix some swagger errors

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -76,7 +76,7 @@ pub fn fetch_user(
     post,
     path = "/auth/login",
     responses(
-        (status = 200, description = "user was successfully authenticated", body = crate::routes::UserCreation),
+        (status = 200, description = "user was successfully authenticated", body = CreateUserResponse),
         (status = 500, description = "postgres pool error"),
         (status = 400, description = "invalid user data")
     ),

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -116,7 +116,7 @@ pub struct DeactivateRequest {
         station::UpdateStationRequest,
         station::SearchStationRequest,
         station::ForceDeleteRequest,
-        station::ApproveStationRequest
+        station::ApproveStationRequest,
     ))
 )]
 pub struct ApiDoc;

--- a/src/routes/region.rs
+++ b/src/routes/region.rs
@@ -65,7 +65,7 @@ pub struct RegionInfoStruct {
     post,
     path = "/region",
     responses(
-        (status = 200, description = "region was successfully created", body = crate::routes::RegionCreationResponse),
+        (status = 200, description = "region was successfully created", body = RegionCreationResponse),
         (status = 500, description = "postgres pool error"),
     ),
 )]

--- a/src/routes/trekkie_runs.rs
+++ b/src/routes/trekkie_runs.rs
@@ -119,10 +119,10 @@ pub async fn trekkie_run_update(
 
     match diesel::update(trekkie_runs.filter(trekkie_id.eq(path.0)))
         .set((
-            start_time.eq(request.start_time.clone()),
-            end_time.eq(request.end_time.clone()),
-            line.eq(request.line.clone()),
-            run.eq(request.run.clone()),
+            start_time.eq(request.start_time),
+            end_time.eq(request.end_time),
+            line.eq(request.line),
+            run.eq(request.run),
         ))
         .get_result::<TrekkieRun>(&mut database_connection)
     {

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -78,7 +78,7 @@ pub struct CreateUserResponse {
     post,
     path = "/user",
     responses(
-       (status = 200, description = "user was successfully created", body = crate::routes::UserCreation),
+       (status = 200, description = "user was successfully created", body = CreateUserResponse),
         (status = 500, description = "postgres pool error"),
         (status = 400, description = "invalid user data"),
     ),


### PR DESCRIPTION
This fixes *some* swagger errors, see #11 

Problems come from bad input to utoipa macros. To fix other errors we need to derive the traits for stuff in `tlms::management`, and also get a `ToSchema` for `Uuid` (which might be more problematic).

Regarding tlms updates, that something I can do as part as my trekkie/lofi integration branch. @revol-xut Thoughts?